### PR TITLE
add initial delay of 20s to the liveness probe (#5)

### DIFF
--- a/charts/prometheus-process-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-process-exporter/templates/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.port }}
+              initialDelaySeconds: 20
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Containers are taking time to start and were killed by the liveness probe which by default results to 3 retries of 10s. Adding an initialDelaySeconds of 20 will help preventing the pods from being killed on fresh start.